### PR TITLE
feat: Improve compatibility with Google Translate

### DIFF
--- a/docs/assets/javascripts/disable-instant-if-translated.js
+++ b/docs/assets/javascripts/disable-instant-if-translated.js
@@ -1,0 +1,23 @@
+// Disable navigation.instant if Google Translate is active
+// (translate.goog or browser extension)
+(function () {
+  const isGoogleTranslateProxy =
+    window.location.hostname.includes("translate.goog");
+
+  // Google Translate browser extension detection:
+  // It injects `translated-ltr` or `translated-rtl` class on <html>
+  const htmlClassList = document.documentElement.classList;
+  const isGoogleTranslateExtension =
+    htmlClassList.contains("translated-ltr") ||
+    htmlClassList.contains("translated-rtl");
+
+  if (isGoogleTranslateProxy || isGoogleTranslateExtension) {
+    // Disable Material instant navigation
+    document.documentElement.removeAttribute("data-md-instant");
+
+    // Optional: log for debugging
+    console.log(
+      "Instant loading disabled because Google Translate is active (proxy or extension).",
+    );
+  }
+})();

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,8 +68,8 @@ theme:
 plugins:
   - redirects:
       redirect_maps:
-        'startup-guide.md': 'configuration/new-user-setup.md'
-        'startup-guide/index.md': 'configuration/new-user-setup.md'
+        "startup-guide.md": "configuration/new-user-setup.md"
+        "startup-guide/index.md": "configuration/new-user-setup.md"
   - open-in-new-tab
   - macros
   - exporter:
@@ -128,6 +128,7 @@ extra_css:
   - assets/stylesheets/extra.css
 
 extra_javascript:
+  - assets/javascripts/disable-instant-if-translated.js
   - assets/javascripts/mathjax.js
   - assets/javascripts/mkdocs-exporter.js
   - https://cdnjs.cloudflare.com/ajax/libs/mathjax/3.2.2/es5/tex-mml-chtml.min.js


### PR DESCRIPTION
Disable `navigation.instant` (instant loading)
when site is translated via translate.goog or Google Translate extension